### PR TITLE
Set up for Coveralls by adding .coveralls.yml file

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: IGM811ozsPMmVZ3n8pnwrt3ddm55qXcfM


### PR DESCRIPTION
Since our repository is a private one, Coveralls requires Travis Pro access, which in turn requires a `.coveralls.yml` to set up an access token between Travis and Coveralls.

This file needs to be present with current and correct token, before a branch can be showed on Coveralls.