### PR TITLE
View details of a job by ID

### DIFF
--- a/jobs/templates/jobs/job_detail.html
+++ b/jobs/templates/jobs/job_detail.html
@@ -1,0 +1,19 @@
+<h1>{{ job.business_title }}</h1>
+
+<ul>
+    <li>#{{ job.job_id }}</li>
+    <li>category: {{ job.job_category }}</li>
+    <li>civil service title: {{ job.civil_service_title }}</li>
+    <li>agency: {{ job.agency }}</li>
+    <li>divsion: {{ job.division }}</li>
+    <li>location: {{ job.work_location }}</li>
+    <li>posting type: {{ job.posting_type }}</li>
+    <li>posting date: {{ job.posting_date }}</li>
+    <li>description: {{ job.job_description }}</li>
+    <li>minimum qualification: {{ job.min_qualifications }}</li>
+    <li>preferred skills: {{ job.preferred_skills }}</li>
+    <li>more info: {{ job.additional_info }}</li>
+    <li>residency requirement: {{ job.residency_requirement }}</li>
+    <li>: {{ job. }}</li>
+
+</ul>

--- a/jobs/templates/jobs/job_detail.html
+++ b/jobs/templates/jobs/job_detail.html
@@ -1,19 +1,40 @@
-<h1>{{ job.business_title }}</h1>
+{% extends "uplyft/base.html" %}
+{% load static %}
 
-<ul>
-    <li>#{{ job.job_id }}</li>
-    <li>category: {{ job.job_category }}</li>
-    <li>civil service title: {{ job.civil_service_title }}</li>
-    <li>agency: {{ job.agency }}</li>
-    <li>divsion: {{ job.division }}</li>
-    <li>location: {{ job.work_location }}</li>
-    <li>posting type: {{ job.posting_type }}</li>
-    <li>posting date: {{ job.posting_date }}</li>
-    <li>description: {{ job.job_description }}</li>
-    <li>minimum qualification: {{ job.min_qualifications }}</li>
-    <li>preferred skills: {{ job.preferred_skills }}</li>
-    <li>more info: {{ job.additional_info }}</li>
-    <li>residency requirement: {{ job.residency_requirement }}</li>
-    <li>: {{ job. }}</li>
+{% block content %}
 
-</ul>
+<div class="container">
+
+   <div class="col-md-12 mb-3 mb-md-0">
+      <div class="card py-4 h-100">
+        <div class="card-body text-center">
+          <h4 class="text-uppercase m-0"> {{ job.business_title }} </h4>
+          <hr class="my-4">
+          <div class="small text-black-50"> {{ job.work_location }} | {{ job.division }} </div>
+            <p> {{ job.agency}} </p>
+        </div>
+      
+    
+
+    <ul>
+        <li>#{{ job.job_id }}</li>
+        <li>category: {{ job.job_category }}</li>
+        <li>civil service title: {{ job.civil_service_title }}</li>
+        <li>agency: {{ job.agency }}</li>
+        <li>divsion: {{ job.division }}</li>
+        <li>location: {{ job.work_location }}</li>
+        <li>posting type: {{ job.posting_type }}</li>
+        <li>posting date: {{ job.posting_date }}</li>
+        <li>description: {{ job.job_description }}</li>
+        <li>minimum qualification: {{ job.min_qualifications }}</li>
+        <li>preferred skills: {{ job.preferred_skills }}</li>
+        <li>more info: {{ job.additional_info }}</li>
+        <li>residency requirement: {{ job.residency_requirement }}</li>
+        <li>: {{ job. }}</li>
+    
+    </ul>
+</div>
+</div>
+  </div>
+
+{% endblock %}

--- a/jobs/templates/jobs/jobs.html
+++ b/jobs/templates/jobs/jobs.html
@@ -28,11 +28,13 @@ body{
   </div>
 </div>
 
+
 <div class="container">
     <div class="row">
         <div class="col-md-9 mt-3 center mx-auto">
             {% for job in jobs %}
-            <div class="card mb-4">
+            <a href="{% url 'jobs:job_detail' job.job_id %}">
+              <div class="card mb-4">
                 <div class="card-body">
                     <h5 class="card-title">{{ job.business_title }}</h5>
                     <span> <small> {{ job.posting_date}} </small> </span>
@@ -49,6 +51,7 @@ body{
                     </p>
                 </div>
             </div>
+            </a>
             {% endfor %}
         </div>
 

--- a/jobs/urls.py
+++ b/jobs/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("", views.JobsView.as_view(), name="jobs"),
     path("load_jobs", views.load_jobs, name="load_jobs"),
     path("search", views.JobAdvancedSearch.as_view(), name="search"),
+    path("<int:pk>", views.JobDetailView.as_view(), name="job_detail"),
 ]

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import render
 from django.db.models import Q
 from django.views.generic.list import ListView
 from django_filters.views import FilterView
+from django.views.generic.detail import DetailView
 from .models import Job
 from .filters import JobFilter
 
@@ -53,6 +54,11 @@ class JobAdvancedSearch(FilterView):
     filterset_class = JobFilter
     template_name = "jobs/job_search.html"
     paginate_by = 10
+
+
+class JobDetailView(DetailView):
+    model = Job
+    template_name = "jobs/job_detail.html"
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Now the user can see the detail of a job on its designated detail page. And when they click a job on job listings, we will take them to the detail page. 

This is an updated pull request from #114 .

