### PR TITLE
sort advanced search results by posting date

### DIFF
--- a/jobs/views.py
+++ b/jobs/views.py
@@ -54,7 +54,7 @@ class JobAdvancedSearch(FilterView):
     filterset_class = JobFilter
     template_name = "jobs/job_search.html"
     paginate_by = 10
-    ordering = ['-posting_date']
+    ordering = ["-posting_date"]
 
 
 class JobDetailView(DetailView):

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -54,6 +54,7 @@ class JobAdvancedSearch(FilterView):
     filterset_class = JobFilter
     template_name = "jobs/job_search.html"
     paginate_by = 10
+    ordering = ['-posting_date']
 
 
 class JobDetailView(DetailView):


### PR DESCRIPTION
Just noticed that the advanced search job cards aren't sorted by date. Added a line to fix this